### PR TITLE
Changed to production version of VCFimport script

### DIFF
--- a/forms/s0901_WESTestResults
+++ b/forms/s0901_WESTestResults
@@ -389,7 +389,7 @@ Private Sub VCFImport_Click()
                 Dim wsh As Object
                 Set wsh = CreateObject("WScript.Shell")
                 pythonPath = "\\gstt.local\Shared\Genetics_Data2\Array\Software\Python\python.exe"
-                ScriptPath = "\\gstt.local\Apps\Moka\Files\Software\VCFImport\VCFImport_case-insensitive.py"
+                ScriptPath = "\\gstt.local\Apps\Moka\Files\Software\VCFImport\VCFImport.py"
                 'Execute python script with required arguments. "2>&1" at the end redirects StdErr (2) to StdOut (1)
                 Set wshexec = wsh.Exec("cmd.exe /S /C " & pythonPath & " " & ScriptPath & " """ & csFileLst & """ " & patID & " " & NGSTestID & " 2>&1")
                 'DoEvents pauses VBA until python script has finished running. wshexec.status is 0 while running and 1 when finished
@@ -1218,6 +1218,3 @@ Dim stDocName As String
     stLinkCriteria = "[Type] = 3 AND [LinkID] = " & Me![NGSTestID]
     DoCmd.OpenForm stDocName, acFormDS, , stLinkCriteria
 End Sub
-
-
-


### PR DESCRIPTION
Accidentally left form pointing to dev version of vcfimport script rather than production. Need to change before rolling out v3.78.