### PR TITLE
Update WES DNA QC queries

### DIFF
--- a/forms/s87022_WESDNAPatients_SQL
+++ b/forms/s87022_WESDNAPatients_SQL
@@ -1,4 +1,4 @@
-SELECT NGSTest.Priority, NGSTest.DateRequested, dbo_Patient_table.PatientTrustID, dbo_Patient_table.LastName, dbo_Patient_table.FirstName, dbo_Patient_table.DoB, Patients.s_StatusOverall, NGSTest.StatusID, gw_GenderTable.Gender, Patients.InternalPatientID, NGSTest.NGSTestID
+SELECT NGSTest.Priority, NGSTest.DateRequested, dbo_Patient_table.PatientTrustID, dbo_Patient_table.LastName, dbo_Patient_table.FirstName, dbo_Patient_table.DoB, NGSTest.StatusID, gw_GenderTable.Gender, Patients.InternalPatientID, NGSTest.NGSTestID
 FROM ((NGSTest INNER JOIN Patients ON NGSTest.InternalPatientID = Patients.InternalPatientID) INNER JOIN dbo_Patient_table ON Patients.PatientID = dbo_Patient_table.PatientTrustID) LEFT JOIN gw_GenderTable ON dbo_Patient_table.GenderID = gw_GenderTable.GenderID
-WHERE (((Patients.s_StatusOverall)=1202218798) AND ((NGSTest.StatusID)=1202218800))
+WHERE (((NGSTest.StatusID)=1202218800))
 ORDER BY NGSTest.Priority, NGSTest.DateRequested;

--- a/forms/s87024_WESDNAQC_SQL
+++ b/forms/s87024_WESDNAQC_SQL
@@ -1,4 +1,4 @@
 SELECT DNA.DNAID, NGSTest.StatusID, NGSTest.Priority, NGSTest.DateRequested, NGSTest.NGSTestID, dbo_Patient_table.PatientTrustID, dbo_Patient_table.[LastName] & ", " & [Firstname] AS Name, ([DNA.Qubit]*[DNA.Volume]/1000) AS TotalDNA, IIf([NGSTest.Priority]=True,"High","") AS PriorityTxt, DNA.DNANumber, Patients.InternalPatientID, DNA.Qubit, DNA.TapeStationDin, DNA.Volume, DNA.DNAComment, DNA.Selected
 FROM ((DNA INNER JOIN Patients ON DNA.InternalPatientID = Patients.InternalPatientID) INNER JOIN NGSTest ON Patients.InternalPatientID = NGSTest.InternalPatientID) INNER JOIN dbo_Patient_table ON Patients.PatientID = dbo_Patient_table.PatientTrustID
-WHERE (((NGSTest.StatusID)=1202218800) AND ((Patients.s_StatusOverall)=1202218798) AND ((DNA.Active)=True))
+WHERE (((NGSTest.StatusID)=1202218800) AND ((DNA.Active)=True))
 ORDER BY NGSTest.Priority, NGSTest.DateRequested;


### PR DESCRIPTION
Identify WES samples requiring DNA QC based on the NGS test status rather than NGS test status and Patient status, means patients which are also undergoing array wont be excluded from the WES pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/woook/moka-fe/511)
<!-- Reviewable:end -->
