### PR TITLE
Bugfix for a status field being editable

### DIFF
--- a/forms/571 HybridisingPatients_SQL
+++ b/forms/571 HybridisingPatients_SQL
@@ -1,0 +1,26 @@
+SELECT Status.Status AS [Array status],
+       Status_1.Status AS [Patient status],
+       Referral.Referral,
+       ArrayLabelling.ArrayRunNumber,
+       Patients.PatientID,
+       Status.StatusID
+
+  FROM ((((Status
+       INNER JOIN ArrayTest
+       ON Status.StatusID = ArrayTest.StatusID)
+       
+       INNER JOIN Patients
+       ON ArrayTest.InternalPatientID = Patients.InternalPatientID)
+
+       INNER JOIN Referral
+       ON ArrayTest.ReferralID = Referral.ReferralID)
+       
+       LEFT JOIN ArrayLabelling
+       ON ArrayTest.DNALabellingID = ArrayLabelling.DNALabellingID)
+
+       INNER JOIN Status AS Status_1
+       ON Patients.s_StatusOverall = Status_1.StatusID
+
+ WHERE Status.StatusID=1168443123
+
+ORDER BY ArrayLabelling.ArrayRunNumber DESC;


### PR DESCRIPTION
Fixes #561 

INC0034515
https://viapath.service-now.com/incident.do?sys_id=ae24050adb253b006d94303c7c9619ef&sysparm_view=&sysparm_view_forced=true&sysparm_time=1558711609400

Related but seperate: the underlying query for form 571 has been updated to filter on status ID rather than status.
Was: `WHERE Status.Status=" Hybridising"`
Now: `WHERE Status.StatusID=1168443123`  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/woook/moka-fe/562)
<!-- Reviewable:end -->
